### PR TITLE
test: fix issue with region used by test

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,75 @@
 <!-- Add a description of module(s) in this repo -->
 This module configures an IBM Cloud Security and Compliance instance.
 
+## Known limitations
+There is currently a known issue with the IBM provider (https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5131) where the provider is always trying to use the us-south endpoint when trying to configure the instance, even if the instance is not in us-south. You will see the following error on apply:
+```
+│ Error: UpdateSettingsWithContext failed The requested resource was not found
+│ {
+│     "StatusCode": 404,
+│     "Headers": {
+│         "Cache-Control": [
+│             "no-store"
+│         ],
+│         "Cf-Cache-Status": [
+│             "DYNAMIC"
+│         ],
+│         "Cf-Ray": [
+│             "854ebcb0de6ebb06-MXP"
+│         ],
+│         "Content-Type": [
+│             "application/json; charset=utf-8"
+│         ],
+│         "Date": [
+│             "Tue, 13 Feb 2024 17:19:35 GMT"
+│         ],
+│         "Server": [
+│             "cloudflare"
+│         ],
+│         "Strict-Transport-Security": [
+│             "max-age=31536000; includeSubDomains"
+│         ],
+│         "Transaction-Id": [
+│             "e2d78bad-a4c6-4dd9-8c47-ffe11088fcde"
+│         ],
+│         "X-Content-Type-Options": [
+│             "nosniff"
+│         ],
+│         "X-Correlation-Id": [
+│             "e2d78bad-a4c6-4dd9-8c47-ffe11088fcde"
+│         ],
+│         "X-Envoy-Upstream-Service-Time": [
+│             "27"
+│         ],
+│         "X-Request-Id": [
+│             "c3eaf1cb-f54b-4fcd-bda6-78f9da654e2c"
+│         ]
+│     },
+│     "Result": {
+│         "errors": [
+│             {
+│                 "code": "not_found",
+│                 "message": "The requested resource was not found",
+│                 "more_info": "https://cloud.ibm.com/apidocs/security-compliance-admin"
+│             }
+│         ],
+│         "status_code": 404,
+│         "trace": "e2d78bad-a4c6-4dd9-8c47-ffe11088fcde"
+│     },
+│     "RawResult": null
+│ }
+│
+│
+│   with module.create_scc_instance.ibm_scc_instance_settings.scc_instance_settings,
+│   on ../../main.tf line 42, in resource "ibm_scc_instance_settings" "scc_instance_settings":
+│   42: resource "ibm_scc_instance_settings" "scc_instance_settings" {
+```
+As a workaround, you can set the following environment variable before running apply:
+```
+export IBMCLOUD_SCC_API_ENDPOINT=https://REGION.compliance.cloud.ibm.com
+```
+where `REGION` is the value you have set for the modules `region` input variable.
+
 <!-- Below content is automatically populated via pre-commit hook -->
 <!-- BEGIN OVERVIEW HOOK -->
 ## Overview

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -2,6 +2,7 @@
 package test
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -15,11 +15,12 @@ const completeExampleDir = "examples/complete"
 
 func setupBasicExampleOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptions {
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
-		Testing:            t,
-		TerraformDir:       dir,
-		Prefix:             prefix,
-		ResourceGroup:      resourceGroup,
-		BestRegionYAMLPath: "../common-dev-assets/common-go-assets/cloudinfo-region-scc-prefs.yaml",
+		Testing:       t,
+		TerraformDir:  dir,
+		Prefix:        prefix,
+		ResourceGroup: resourceGroup,
+		Region:        "us-south", // need to use us-south until this is fixed https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5131
+		// BestRegionYAMLPath: "../common-dev-assets/common-go-assets/cloudinfo-region-scc-prefs.yaml",
 	})
 	return options
 }
@@ -35,7 +36,8 @@ func setupCompleteExampleOptions(t *testing.T, prefix string, dir string) *testh
 		Testing:      t,
 		TerraformDir: dir,
 		Prefix:       prefix,
-		Region:       validRegions[rand.Intn(len(validRegions))],
+		// Region:       validRegions[rand.Intn(len(validRegions))],
+		Region: "us-south", // need to use us-south until this is fixed https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5131
 		/*
 		 To prevent clashes, comment out the 'ResourceGroup' input in the tests to create a unique resource group,
 		 as only one instance of Event Notification (Lite) is allowed per resource group.

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -8,12 +8,11 @@ import (
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testhelper"
 )
 
-// Use existing resource group
-const resourceGroup = "geretain-test-resources"
+const resourceGroup = "geretain-test-resources" // Use existing resource group
 const basicExampleDir = "examples/basic"
 const completeExampleDir = "examples/complete"
 
-func setupOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptions {
+func setupBasicExampleOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptions {
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
 		Testing:            t,
 		TerraformDir:       dir,
@@ -25,11 +24,17 @@ func setupOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptio
 }
 
 func setupCompleteExampleOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptions {
+	// Use a region that is supported for both Event Notifications and SCC
+	validRegions := []string{
+		"us-south",
+		"eu-de",
+		"eu-es",
+	}
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
-		Testing:            t,
-		TerraformDir:       dir,
-		Prefix:             prefix,
-		BestRegionYAMLPath: "../common-dev-assets/common-go-assets/cloudinfo-region-scc-prefs.yaml",
+		Testing:      t,
+		TerraformDir: dir,
+		Prefix:       prefix,
+		Region:       validRegions[rand.Intn(len(validRegions))],
 		/*
 		 To prevent clashes, comment out the 'ResourceGroup' input in the tests to create a unique resource group,
 		 as only one instance of Event Notification (Lite) is allowed per resource group.

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -70,7 +70,7 @@ func TestRunBasicExample(t *testing.T) {
 func TestRunCompleteExampleUpgrade(t *testing.T) {
 	t.Parallel()
 
-	options := setupCompleteExampleOptions(t, "scc-upg", basicExampleDir)
+	options := setupCompleteExampleOptions(t, "scc-upg", completeExampleDir)
 
 	output, err := options.RunTestUpgrade()
 	if !options.UpgradeTestSkipped {

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -2,7 +2,7 @@
 package test
 
 import (
-	"math/rand"
+	// "math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,11 +27,11 @@ func setupBasicExampleOptions(t *testing.T, prefix string, dir string) *testhelp
 
 func setupCompleteExampleOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptions {
 	// Use a region that is supported for both Event Notifications and SCC
-	validRegions := []string{
-		"us-south",
-		"eu-de",
-		"eu-es",
-	}
+	// validRegions := []string{
+	// 	"us-south",
+	// 	"eu-de",
+	// 	"eu-es",
+	// }
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
 		Testing:      t,
 		TerraformDir: dir,

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -57,17 +57,17 @@ func TestRunCompleteExample(t *testing.T) {
 func TestRunBasicExample(t *testing.T) {
 	t.Parallel()
 
-	options := setupOptions(t, "scc", basicExampleDir)
+	options := setupBasicExampleOptions(t, "scc", basicExampleDir)
 
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")
 	assert.NotNil(t, output, "Expected some output")
 }
 
-func TestRunUpgradeExample(t *testing.T) {
+func TestRunCompleteExampleUpgrade(t *testing.T) {
 	t.Parallel()
 
-	options := setupOptions(t, "scc-upg", basicExampleDir)
+	options := setupCompleteExampleOptions(t, "scc-upg", basicExampleDir)
 
 	output, err := options.RunTestUpgrade()
 	if !options.UpgradeTestSkipped {


### PR DESCRIPTION
### Description

`ca-tor` is not supported by Event Notifications, but it is by SCC, so the complete example fails when it selects `ca-tor`

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
