### PR TITLE
fix: require ibm provider version >= 1.63.0 which has fix for region bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,75 +10,6 @@
 <!-- Add a description of module(s) in this repo -->
 This module configures an IBM Cloud Security and Compliance instance.
 
-## Known limitations
-There is currently a known issue with the IBM provider (https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5131) where the provider is always trying to use the us-south endpoint when trying to configure the instance, even if the instance is not in us-south. You will see the following error on apply:
-```
-│ Error: UpdateSettingsWithContext failed The requested resource was not found
-│ {
-│     "StatusCode": 404,
-│     "Headers": {
-│         "Cache-Control": [
-│             "no-store"
-│         ],
-│         "Cf-Cache-Status": [
-│             "DYNAMIC"
-│         ],
-│         "Cf-Ray": [
-│             "854ebcb0de6ebb06-MXP"
-│         ],
-│         "Content-Type": [
-│             "application/json; charset=utf-8"
-│         ],
-│         "Date": [
-│             "Tue, 13 Feb 2024 17:19:35 GMT"
-│         ],
-│         "Server": [
-│             "cloudflare"
-│         ],
-│         "Strict-Transport-Security": [
-│             "max-age=31536000; includeSubDomains"
-│         ],
-│         "Transaction-Id": [
-│             "e2d78bad-a4c6-4dd9-8c47-ffe11088fcde"
-│         ],
-│         "X-Content-Type-Options": [
-│             "nosniff"
-│         ],
-│         "X-Correlation-Id": [
-│             "e2d78bad-a4c6-4dd9-8c47-ffe11088fcde"
-│         ],
-│         "X-Envoy-Upstream-Service-Time": [
-│             "27"
-│         ],
-│         "X-Request-Id": [
-│             "c3eaf1cb-f54b-4fcd-bda6-78f9da654e2c"
-│         ]
-│     },
-│     "Result": {
-│         "errors": [
-│             {
-│                 "code": "not_found",
-│                 "message": "The requested resource was not found",
-│                 "more_info": "https://cloud.ibm.com/apidocs/security-compliance-admin"
-│             }
-│         ],
-│         "status_code": 404,
-│         "trace": "e2d78bad-a4c6-4dd9-8c47-ffe11088fcde"
-│     },
-│     "RawResult": null
-│ }
-│
-│
-│   with module.create_scc_instance.ibm_scc_instance_settings.scc_instance_settings,
-│   on ../../main.tf line 42, in resource "ibm_scc_instance_settings" "scc_instance_settings":
-│   42: resource "ibm_scc_instance_settings" "scc_instance_settings" {
-```
-As a workaround, you can set the following environment variable before running apply:
-```
-export IBMCLOUD_SCC_API_ENDPOINT=https://REGION.compliance.cloud.ibm.com
-```
-where `REGION` is the value you have set for the modules `region` input variable.
-
 <!-- Below content is automatically populated via pre-commit hook -->
 <!-- BEGIN OVERVIEW HOOK -->
 ## Overview
@@ -133,7 +64,7 @@ You need the following permissions to run this module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0, <1.7.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.62.0, <2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.63.0, <2.0.0 |
 
 ### Modules
 

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.62.0"
+      version = "1.63.0"
     }
   }
 }

--- a/examples/complete/version.tf
+++ b/examples/complete/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.62.0"
+      version = ">= 1.63.0"
     }
   }
 }

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -2,7 +2,7 @@
 package test
 
 import (
-	// "math/rand"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,29 +15,27 @@ const completeExampleDir = "examples/complete"
 
 func setupBasicExampleOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptions {
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
-		Testing:       t,
-		TerraformDir:  dir,
-		Prefix:        prefix,
-		ResourceGroup: resourceGroup,
-		Region:        "us-south", // need to use us-south until this is fixed https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5131
-		// BestRegionYAMLPath: "../common-dev-assets/common-go-assets/cloudinfo-region-scc-prefs.yaml",
+		Testing:            t,
+		TerraformDir:       dir,
+		Prefix:             prefix,
+		ResourceGroup:      resourceGroup,
+		BestRegionYAMLPath: "../common-dev-assets/common-go-assets/cloudinfo-region-scc-prefs.yaml",
 	})
 	return options
 }
 
 func setupCompleteExampleOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptions {
 	// Use a region that is supported for both Event Notifications and SCC
-	// validRegions := []string{
-	// 	"us-south",
-	// 	"eu-de",
-	// 	"eu-es",
-	// }
+	validRegions := []string{
+		"us-south",
+		"eu-de",
+		"eu-es",
+	}
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
 		Testing:      t,
 		TerraformDir: dir,
 		Prefix:       prefix,
-		// Region:       validRegions[rand.Intn(len(validRegions))],
-		Region: "us-south", // need to use us-south until this is fixed https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5131
+		Region:       validRegions[rand.Intn(len(validRegions))],
 		/*
 		 To prevent clashes, comment out the 'ResourceGroup' input in the tests to create a unique resource group,
 		 as only one instance of Event Notification (Lite) is allowed per resource group.

--- a/version.tf
+++ b/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">=1.62.0, <2.0.0"
+      version = ">=1.63.0, <2.0.0"
     }
   }
 }


### PR DESCRIPTION
### Description

The fix for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5131 has been included in 1.63.0, so updating module to require this version or later, and removed limitation section from docs

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
