### PR TITLE
feat: new scc code to retrieve latest scc profile version

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -94,7 +94,7 @@ module "create_scc_instance" {
 
 module "create_profile_attachment" {
   source                 = "../../modules/attachment"
-  profile_name           = "CIS IBM Cloud Foundations Benchmark v1.1.0"
+  profile_name           = "SOC 2"
   profile_version        = "latest"
   scc_instance_id        = module.create_scc_instance.guid
   attachment_name        = "${var.prefix}-attachment"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -94,7 +94,7 @@ module "create_scc_instance" {
 
 module "create_profile_attachment" {
   source                 = "../../modules/attachment"
-  profile_name           = "SOC 2"
+  profile_name           = "CIS IBM Cloud Foundations Benchmark v1.1.0"
   profile_version        = "latest"
   scc_instance_id        = module.create_scc_instance.guid
   attachment_name        = "${var.prefix}-attachment"

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -63,12 +63,7 @@ output "wp_crn" {
   value       = module.scc_wp.crn
 }
 
-output "sorted_list" {
-  description = "SCC profile attachment parameters"
-  value       = module.create_profile_attachment.sorted_list
-}
-
-output "latest_profile" {
-  description = "SCC profile attachment parameters"
-  value       = module.create_profile_attachment.latest_profile
+output "profile" {
+  description = "SCC profile details"
+  value       = module.create_profile_attachment.profile
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -58,12 +58,17 @@ output "scc_profile_attachment_id" {
   value       = module.create_profile_attachment.id
 }
 
-output "scc_profile_attachment_parameters" {
-  description = "SCC profile attachment ID"
-  value       = module.create_profile_attachment.attachment_parameters
-}
-
 output "wp_crn" {
   description = "CRN of created SCC WP instance."
   value       = module.scc_wp.crn
+}
+
+output "sorted_list" {
+  description = "SCC profile attachment parameters"
+  value       = module.create_profile_attachment.sorted_list
+}
+
+output "latest_profile" {
+  description = "SCC profile attachment parameters"
+  value       = module.create_profile_attachment.latest_profile
 }

--- a/modules/attachment/README.md
+++ b/modules/attachment/README.md
@@ -75,6 +75,5 @@ No modules.
 |------|-------------|
 | <a name="output_attachment_parameters"></a> [attachment\_parameters](#output\_attachment\_parameters) | SCC profile attachment parameters |
 | <a name="output_id"></a> [id](#output\_id) | SCC profile attachment ID |
-| <a name="output_latest_profile"></a> [latest\_profile](#output\_latest\_profile) | SCC profile attachment parameters |
-| <a name="output_sorted_list"></a> [sorted\_list](#output\_sorted\_list) | SCC profile attachment parameters |
+| <a name="output_profile"></a> [profile](#output\_profile) | SCC profile details |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/attachment/README.md
+++ b/modules/attachment/README.md
@@ -75,4 +75,6 @@ No modules.
 |------|-------------|
 | <a name="output_attachment_parameters"></a> [attachment\_parameters](#output\_attachment\_parameters) | SCC profile attachment parameters |
 | <a name="output_id"></a> [id](#output\_id) | SCC profile attachment ID |
+| <a name="output_latest_profile"></a> [latest\_profile](#output\_latest\_profile) | SCC profile attachment parameters |
+| <a name="output_sorted_list"></a> [sorted\_list](#output\_sorted\_list) | SCC profile attachment parameters |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/attachment/main.tf
+++ b/modules/attachment/main.tf
@@ -16,20 +16,20 @@ data "ibm_scc_profiles" "scc_profiles" {
 }
 
 locals {
-  # Get profiles by name matching that provided in var.profile_name
-  relevant_profiles = [
+  # Get profile and its various versions by name matching that provided in var.profile_name
+  relevant_profile_versions = [
     for profile in data.ibm_scc_profiles.scc_profiles.profiles : profile if profile.profile_name == var.profile_name
   ]
 
   # Sort profile versions from lowest to highest
-  sorted_profile_versions = sort(local.relevant_profiles[*].profile_version)
+  sorted_profile_versions = sort(local.relevant_profile_versions[*].profile_version)
 
   # Create sorted list of profiles, ordered from lowest to highest profile version
   sorted_list = flatten(
     [
       for version in local.sorted_profile_versions :
       [
-        for profile in local.relevant_profiles :
+        for profile in local.relevant_profile_versions :
         profile if version == profile.profile_version
       ]
     ]

--- a/modules/attachment/outputs.tf
+++ b/modules/attachment/outputs.tf
@@ -8,12 +8,7 @@ output "attachment_parameters" {
   value       = resource.ibm_scc_profile_attachment.scc_profile_attachment.attachment_parameters
 }
 
-output "sorted_list" {
-  description = "SCC profile attachment parameters"
-  value       = local.sorted_list
-}
-
-output "latest_profile" {
-  description = "SCC profile attachment parameters"
-  value       = local.latest_profile
+output "profile" {
+  description = "SCC profile details"
+  value       = local.profile
 }

--- a/modules/attachment/outputs.tf
+++ b/modules/attachment/outputs.tf
@@ -7,3 +7,13 @@ output "attachment_parameters" {
   description = "SCC profile attachment parameters"
   value       = resource.ibm_scc_profile_attachment.scc_profile_attachment.attachment_parameters
 }
+
+output "sorted_list" {
+  description = "SCC profile attachment parameters"
+  value       = local.sorted_list
+}
+
+output "latest_profile" {
+  description = "SCC profile attachment parameters"
+  value       = local.latest_profile
+}


### PR DESCRIPTION
### Description

The logic [here](https://github.com/terraform-ibm-modules/terraform-ibm-scc/blob/13e104e88ca1790b171431d434fdc05a5af7d695/modules/attachment/main.tf#L19-L25) assumes that each profile name will always have a latest = true value. However we have seen the SCC team change the profile names, meaning we can no longer rely on that logic.

Implementing our own logic to determine the latest version of a profile.

lookup all versions of a profile
sort them
return the latest
That way we ensure there is ALWAYS a latest version for every profile name
### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

update SCC logic around determining latest profile version

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
