### PR TITLE
feat: add access tags to scc resource instance and expose in examples + test

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ You need the following permissions to run this module.
 | [ibm_iam_authorization_policy.scc_cos_s2s_access](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/iam_authorization_policy) | resource |
 | [ibm_iam_authorization_policy.scc_wp_s2s_access](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/iam_authorization_policy) | resource |
 | [ibm_resource_instance.scc_instance](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/resource_instance) | resource |
+| [ibm_resource_tag.access_tags](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/resource_tag) | resource |
 | [ibm_scc_instance_settings.scc_instance_settings](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/scc_instance_settings) | resource |
 | [ibm_scc_provider_type_instance.scc_provider_type_instance](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/scc_provider_type_instance) | resource |
 | [time_sleep.wait_for_scc_cos_authorization_policy](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
@@ -93,6 +94,7 @@ You need the following permissions to run this module.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_access_tags"></a> [access\_tags](#input\_access\_tags) | A list of access tags applied to the resource instance created by the module | `list(string)` | `[]` | no |
 | <a name="input_attach_wp_to_scc_instance"></a> [attach\_wp\_to\_scc\_instance](#input\_attach\_wp\_to\_scc\_instance) | When set to true, a value must be passed for the `wp_instance_crn` inout variable. | `string` | `false` | no |
 | <a name="input_cbr_rules"></a> [cbr\_rules](#input\_cbr\_rules) | (Optional, list) List of CBR rules to create | <pre>list(object({<br>    description = string<br>    account_id  = string<br>    rule_contexts = list(object({<br>      attributes = optional(list(object({<br>        name  = string<br>        value = string<br>    }))) }))<br>    enforcement_mode = string<br>  }))</pre> | `[]` | no |
 | <a name="input_cos_bucket"></a> [cos\_bucket](#input\_cos\_bucket) | The name of the Cloud Object Storage bucket to be used in SCC instance | `string` | n/a | yes |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -21,6 +21,7 @@ module "create_scc_instance" {
   region                            = var.region
   resource_group_id                 = module.resource_group.resource_group_id
   resource_tags                     = var.resource_tags
+  access_tags                       = var.access_tags
   cos_bucket                        = module.cos.bucket_name
   cos_instance_crn                  = module.cos.cos_instance_id
   attach_wp_to_scc_instance         = false

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -31,3 +31,9 @@ variable "resource_tags" {
   description = "Optional list of tags to be added to created resources"
   default     = []
 }
+
+variable "access_tags" {
+  type        = list(string)
+  description = "Optional list of access tags to be added to the created resource instance"
+  default     = []
+}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -61,6 +61,7 @@ module "create_scc_instance" {
   region                            = var.region
   resource_group_id                 = module.resource_group.resource_group_id
   resource_tags                     = var.resource_tags
+  access_tags                       = var.access_tags
   cos_bucket                        = module.cos.bucket_name
   cos_instance_crn                  = module.cos.cos_instance_id
   en_instance_crn                   = module.event_notification.crn

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -31,3 +31,9 @@ variable "resource_tags" {
   description = "Optional list of tags to be added to created resources"
   default     = []
 }
+
+variable "access_tags" {
+  type        = list(string)
+  description = "Optional list of access tags to be added to the created resource instance"
+  default     = []
+}

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,12 @@ resource "ibm_resource_instance" "scc_instance" {
   tags              = var.resource_tags
 }
 
+resource "ibm_resource_tag" "access_tags" {
+  resource_id = ibm_resource_instance.scc_instance.crn
+  tags        = var.access_tags
+  tag_type    = "access"
+}
+
 data "ibm_scc_provider_types" "scc_provider_types" {
   count       = var.attach_wp_to_scc_instance ? 1 : 0
   instance_id = ibm_resource_instance.scc_instance.guid

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -2,16 +2,33 @@
 package test
 
 import (
+	"log"
 	"math/rand"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/common"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testhelper"
 )
 
 const resourceGroup = "geretain-test-resources" // Use existing resource group
 const basicExampleDir = "examples/basic"
 const completeExampleDir = "examples/complete"
+const yamlLocation = "../common-dev-assets/common-go-assets/common-permanent-resources.yaml"
+
+var permanentResources map[string]interface{}
+
+func TestMain(m *testing.M) {
+	// Read the YAML file contents
+	var err error
+	permanentResources, err = common.LoadMapFromYaml(yamlLocation)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	os.Exit(m.Run())
+}
 
 func setupBasicExampleOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptions {
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
@@ -20,6 +37,9 @@ func setupBasicExampleOptions(t *testing.T, prefix string, dir string) *testhelp
 		Prefix:             prefix,
 		ResourceGroup:      resourceGroup,
 		BestRegionYAMLPath: "../common-dev-assets/common-go-assets/cloudinfo-region-scc-prefs.yaml",
+		TerraformVars: map[string]interface{}{
+			"access_tags": permanentResources["accessTags"],
+		},
 	})
 	return options
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,19 @@ variable "resource_tags" {
   default     = []
 }
 
+variable "access_tags" {
+  type        = list(string)
+  description = "A list of access tags applied to the resource instance created by the module"
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for tag in var.access_tags : can(regex("[\\w\\-_\\.]+:[\\w\\-_\\.]+", tag)) && length(tag) <= 128
+    ])
+    error_message = "Access tags must match the regular expression \"[\\w\\-_\\.]+:[\\w\\-_\\.]+\", see https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#limits for more details"
+  }
+}
+
 variable "instance_name" {
   type        = string
   description = "Name of the security and compliance instance that will be provisioned by this module"


### PR DESCRIPTION
### Description

adds the ability to apply access tags to the SCC resource instance and exposes that to the example, also added access tags from permanent resources to the basic example to test the functionality moving forward

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

Add the ability to use access tags on the SCC instance

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
