### PR TITLE
Add fix for EN integration

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-12-10T06:40:44Z",
+  "generated_at": "2023-12-11T06:40:44Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You need the following permissions to run this module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.64.1, <2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.71.3, <2.0.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1, <1.0.0 |
 
 ### Modules
@@ -101,6 +101,8 @@ You need the following permissions to run this module.
 | <a name="input_cos_bucket"></a> [cos\_bucket](#input\_cos\_bucket) | The name of the Cloud Object Storage bucket to be used in SCC instance. Required when creating a new SCC instance. | `string` | `null` | no |
 | <a name="input_cos_instance_crn"></a> [cos\_instance\_crn](#input\_cos\_instance\_crn) | CRN of the Cloud Object Storage to store SCC data. Required when creating a new SCC instance. | `string` | `null` | no |
 | <a name="input_en_instance_crn"></a> [en\_instance\_crn](#input\_en\_instance\_crn) | The CRN of Event Notifications instance to be used with SCC. If no value is provided, Event Notifications will not be enabled for this SCC instance | `string` | `null` | no |
+| <a name="input_en_source_description"></a> [en\_source\_description](#input\_en\_source\_description) | Optional description to give for the Event Notifications integration source. Only used if a value is passed for `en_instance_crn`. | `string` | `null` | no |
+| <a name="input_en_source_name"></a> [en\_source\_name](#input\_en\_source\_name) | The source name to use for the Event Notifications integration. Required if a value is passed for `en_instance_crn`. | `string` | `null` | no |
 | <a name="input_existing_scc_instance_crn"></a> [existing\_scc\_instance\_crn](#input\_existing\_scc\_instance\_crn) | The CRN of an existing Security and Compliance Center instance. If not supplied, a new instance will be created. | `string` | `null` | no |
 | <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | Name of the security and compliance instance that will be provisioned by this module | `string` | n/a | yes |
 | <a name="input_plan"></a> [plan](#input\_plan) | Pricing plan to create SCC instance. Options include security-compliance-center-standard-plan or security-compliance-center-trial-plan | `string` | `"security-compliance-center-standard-plan"` | no |

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.66.0"
+      version = ">= 1.71.3"
     }
   }
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -68,6 +68,7 @@ module "create_scc_instance" {
   cos_bucket                        = var.existing_scc_instance_crn == null ? module.cos[0].bucket_name : null
   cos_instance_crn                  = var.existing_scc_instance_crn == null ? module.cos[0].cos_instance_id : null
   en_instance_crn                   = module.event_notification.crn
+  en_source_name                    = module.event_notification.event_notification_instance_name
   skip_cos_iam_authorization_policy = false
   attach_wp_to_scc_instance         = true
   skip_scc_wp_auth_policy           = false

--- a/examples/complete/version.tf
+++ b/examples/complete/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.64.1"
+      version = ">= 1.71.3"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -83,6 +83,8 @@ resource "time_sleep" "wait_for_scc_cos_authorization_policy" {
 locals {
   # tflint-ignore: terraform_unused_declarations
   validate_new_scc_instance_cos_setting = var.existing_scc_instance_crn == null && anytrue([var.cos_bucket == null, var.cos_instance_crn == null]) ? tobool("when creating a new SCC instance, both both `var.cos_instance_crn` and `var.cos_bucket` are required.") : false
+  # tflint-ignore: terraform_unused_declarations
+  validate_en_integration = var.en_instance_crn != null && var.en_source_name == null ? tobool("When passing a value for 'en_instance_crn', a value must also be passed for 'en_source_name'.") : false
 }
 
 # attach a COS bucket and an event notifications instance
@@ -91,7 +93,9 @@ resource "ibm_scc_instance_settings" "scc_instance_settings" {
   count       = var.existing_scc_instance_crn == null ? 1 : 0
   instance_id = resource.ibm_resource_instance.scc_instance[0].guid
   event_notifications {
-    instance_crn = var.en_instance_crn
+    instance_crn       = var.en_instance_crn
+    source_name        = var.en_source_name
+    source_description = var.en_source_description
   }
   object_storage {
     instance_crn = var.cos_instance_crn

--- a/modules/attachment/README.md
+++ b/modules/attachment/README.md
@@ -38,7 +38,7 @@ module "create_scc_profile_attachment " {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.64.1, <2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.71.3, <2.0.0 |
 
 ### Modules
 

--- a/modules/attachment/version.tf
+++ b/modules/attachment/version.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">=1.64.1, <2.0.0"
+      version = ">=1.71.3, <2.0.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,18 @@ variable "en_instance_crn" {
   description = "The CRN of Event Notifications instance to be used with SCC. If no value is provided, Event Notifications will not be enabled for this SCC instance"
 }
 
+variable "en_source_name" {
+  type        = string
+  default     = null
+  description = "The source name to use for the Event Notifications integration. Required if a value is passed for `en_instance_crn`."
+}
+
+variable "en_source_description" {
+  type        = string
+  default     = null
+  description = "Optional description to give for the Event Notifications integration source. Only used if a value is passed for `en_instance_crn`."
+}
+
 variable "skip_cos_iam_authorization_policy" {
   type        = bool
   default     = false

--- a/version.tf
+++ b/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">=1.64.1, <2.0.0"
+      version = ">=1.71.3, <2.0.0"
     }
 
     time = {


### PR DESCRIPTION
### Description

Added a fix for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5817
This means a value needs to be passed for `en_source_name` when configuring EN integration now. 

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
