### PR TITLE
fix: add error handling for incorrect profile name

### DIFF
--- a/modules/attachment/main.tf
+++ b/modules/attachment/main.tf
@@ -35,8 +35,10 @@ locals {
     ]
   )
 
+  validate_profile_name = length(local.sorted_list) == 0 ? tobool("Could not find a valid profile name ${var.profile_name}") : true
+
   # Retrieve profile with the latest version by getting last element in sorted list
-  latest_profile = local.sorted_list[length(local.sorted_list) - 1]
+  latest_profile = local.validate_profile_name ? local.sorted_list[length(local.sorted_list) - 1] : null
 
   profile_map = var.profile_version == "latest" ? {
     (var.profile_name) = local.latest_profile
@@ -46,9 +48,9 @@ locals {
   }
 
   # tflint-ignore: terraform_unused_declarations
-  validate_profile = lookup(local.profile_map, var.profile_name, null) == null ? tobool("Could not find a valid profile name ${var.profile_name} and matching version ${var.profile_version}") : true
+  validate_profile_version = lookup(local.profile_map, var.profile_name, null) == null ? tobool("Could not find a valid profile name ${var.profile_name} and matching version ${var.profile_version}") : true
 
-  profile = local.validate_profile ? local.profile_map[var.profile_name] : null
+  profile = local.validate_profile_version ? local.profile_map[var.profile_name] : null
 }
 
 data "ibm_scc_profile" "scc_profile" {


### PR DESCRIPTION
### Description

add error handling for incorrect profile name
https://github.com/terraform-ibm-modules/terraform-ibm-scc/issues/202

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Add error handling for when user inputs incorrect profile name.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
