### PR TITLE
fix: remove workaround for provider issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You need the following permissions to run this module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.76.0, <2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.77.1, <2.0.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.12.1, <1.0.0 |
 
 ### Modules

--- a/examples/advanced/version.tf
+++ b/examples/advanced/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.76.0"
+      version = "1.77.1"
     }
   }
 }

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.76.0"
+      version = ">= 1.77.1"
     }
   }
 }

--- a/modules/attachment/README.md
+++ b/modules/attachment/README.md
@@ -42,7 +42,6 @@ No modules.
 | Name | Type |
 |------|------|
 | [ibm_scc_profile_attachment.profile_attachment](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/scc_profile_attachment) | resource |
-| [terraform_data.replacement](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [ibm_scc_profile.scc_profile](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/scc_profile) | data source |
 | [ibm_scc_profiles.scc_profiles](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/scc_profiles) | data source |
 

--- a/modules/attachment/main.tf
+++ b/modules/attachment/main.tf
@@ -99,15 +99,4 @@ resource "ibm_scc_profile_attachment" "profile_attachment" {
       threshold_limit    = var.notification_threshold_limit
     }
   }
-
-  lifecycle {
-    replace_triggered_by = [terraform_data.replacement]
-  }
-
-}
-
-# workaround for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6044
-# approach based on https://developer.hashicorp.com/terraform/language/resources/terraform-data#example-usage-data-for-replace_triggered_by
-resource "terraform_data" "replacement" {
-  input = var.scope_ids
 }

--- a/version.tf
+++ b/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">=1.76.0, <2.0.0"
+      version = ">=1.77.1, <2.0.0"
     }
 
     time = {


### PR DESCRIPTION
### Description

Remove workaround for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6044 since its fixed in latest provider release. The attachment resource now supports update in place

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
